### PR TITLE
BAH-3835 | Add function to get trivy count summary as txt file

### DIFF
--- a/image-scanner.sh
+++ b/image-scanner.sh
@@ -15,6 +15,79 @@
 # retrieves a list of Docker repositories from Docker Hub and runs Trivy scans on each image 
 # to generate security reports. These reports are saved as HTML files in a designated directory.
 
+# Function to generate text table row for severity counts
+function severity_count_row() {
+  printf "%-40s %-10s %-10s %-10s %-10s %-10s\n" "$1" "$2" "$3" "$4" "$5" "$6"
+}
+
+function get_vulnerabilities_count() {
+    image=$1
+    report_text=""
+    scan_results_file=$(mktemp)
+    trivy image --scanners vuln -f json "$image" > "$scan_results_file"
+    if [ $? -ne 0 ]; then
+        report_text+=$(severity_count_row "$image (Failed)" "-" "-" "-" "-" "-")
+        report_text+="\n"
+        echo "$report_text"
+        return 1
+    fi
+    # Check if there are vulnerabilities
+    vulnerabilities=$(jq '.["Results"][0]["Vulnerabilities"] | length > 0' "$scan_results_file")
+
+    if [[ "$vulnerabilities" != "true" ]]; then
+        report_text+=$(severity_count_row "$image" "0" "0" "0" "0" "0")
+        report_text+="\n"
+        echo "$report_text"
+        return 0
+    fi
+
+    declare -A severity_count
+    severity_count=(
+        ["CRITICAL"]=0
+        ["HIGH"]=0
+        ["MEDIUM"]=0
+        ["LOW"]=0
+        ["UNKNOWN"]=0
+    )
+
+    results_length=$(jq '.["Results"] | length' "$scan_results_file")
+    for ((i = 0; i < results_length; i++)); do
+        # Check if there are vulnerabilities for the current result
+        has_vulnerabilities=$(jq ".Results[$i] | has(\"Vulnerabilities\")" "$scan_results_file")
+        if [[ "$has_vulnerabilities" != "true" ]]; then
+        continue
+        fi
+
+        # Extract vulnerabilities for the current result
+        vulnerabilities=$(jq -c ".Results[$i].Vulnerabilities[]" "$scan_results_file")
+
+        # Loop over each vulnerability extracted from the JSON file
+        while IFS=$'\n' read -r vulnerability; do
+            severity=$(jq -r '.Severity' <<< "$vulnerability")
+            # Update severity count
+            if [[ -n "$severity" ]]; then
+            ((severity_count["$severity"]++))
+            fi
+        done <<< "$vulnerabilities"
+    done
+
+    for severity in "CRITICAL" "HIGH" "MEDIUM" "LOW" "UNKNOWN"; do
+        count="${severity_count["$severity"]}"
+        if [[ ! $count -gt 0 ]]; then
+        severity_count["$severity"]=0
+        fi
+    done
+    # Add severity count row for the current image
+
+    report_text+=$(severity_count_row "$image" "${severity_count["CRITICAL"]}" "${severity_count["HIGH"]}" "${severity_count["MEDIUM"]}" "${severity_count["LOW"]}" "${severity_count["UNKNOWN"]}")
+    report_text+="\n"
+
+    # Clean up the temporary file
+    rm "$scan_results_file"
+
+    echo "$report_text"
+
+}
 # Check if the organization name is provided as an argument
 if [ -z "$1" ]; then
     echo "Error: Please provide the Docker organization name as an argument."
@@ -34,17 +107,25 @@ else
     echo "Found trivy, using trivy v$(trivy -v | cut -d ' ' -f 2)"
 fi
 
+# Start the text report
+summary_file_output="Trivy Scan Results Summary\n"
+summary_file_output+="===================\n"
+summary_file_output+="$(printf "%-40s %-10s %-10s %-10s %-10s %-10s\n" "Image" "CRITICAL" "HIGH" "MEDIUM" "LOW" "UNKNOWN")"
+summary_file_output+="\n$(printf '%.0s-' {1..90})\n"
+
 echo "Retrieving repository list ..."
 REPO_LIST=$(curl -s "https://hub.docker.com/v2/repositories/${ORG}/?page_size=100" | jq -r '.results|.[]|.name')
 
 # Get today's date in the desired format for folder naming
 TODAY_DATE=$(date +'%d-%m-%Y')
+CURRENT_TIME=$(date +'%H-%M-%S')
 # Define the root and sub directory name
 ROOT_DIR="image-scanner-reports"
-DIR="bahmni-${TODAY_DATE}"
+DIR="bahmni-${TODAY_DATE}_${CURRENT_TIME}"
 
 # Create the root and sub directory if it doesn't exist
 mkdir -p "$ROOT_DIR/$DIR"
+mkdir -p "$ROOT_DIR/summary"
 
 echo "Generating scan report...."
 
@@ -54,12 +135,14 @@ for image in $REPO_LIST; do
     image_name=$(echo "$image" | tr '/' '-')
 
     # Define the Output File
-    output_file_txt="$ROOT_DIR/${DIR}/${image}-${TODAY_DATE}.html"
+    output_file_txt="$ROOT_DIR/${DIR}/${image}.html"
 
     # Run Trivy scan on the image
     echo "Scanning image: $image"
     trivy image --severity HIGH,CRITICAL --format template --template "@html.tpl" --output "$output_file_txt" "${ORG}/$image_name"
     echo "" >> "$output_file_txt"
+
+    summary_file_output+="$(get_vulnerabilities_count "${ORG}/$image_name")"
 
     # Check if Trivy scan was successful
     if [ $? -eq 0 ]; then
@@ -68,3 +151,4 @@ for image in $REPO_LIST; do
         echo "Error: Trivy scan failed for $image."
     fi
 done
+echo -e "$summary_file_output" > "$ROOT_DIR/summary/${TODAY_DATE}_${CURRENT_TIME}.txt"


### PR DESCRIPTION
This PR updates the image scanner script to generate a summay report of the count of vulnerabilities in the given namespace. The reports will be stored in a summary subfolder with the timestamp as the file name. The script is merged into existing script from the PR #5 .
