### PR TITLE
BAH-4107 | Add. Optional appversionFile Argument to setArtifactVersion.sh

### DIFF
--- a/setArtifactVersion.sh
+++ b/setArtifactVersion.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 set -e
 
+appversionFile=${2:-package/.appversion}
+
 verifyReleaseVersion(){
   version=$1
   tagCount=$(curl -s https://api.github.com/repos/$GITHUB_REPOSITORY/tags | jq --arg tagName "$version"  '[.[] | select( .name == $tagName)] | length')
   if [ $tagCount -gt 0 ]; then
-    echo "Error: Version $version already released. Please update your version in package/.appversion"
+    echo "Error: Version $version already released. Please update your version in $appversionFile"
     exit 1
   fi
 }
@@ -29,7 +31,7 @@ case $GITHUB_REF in
       ;;
   *)
       echo "Current action is neither tag nor release branch.."
-      version=$(cat package/.appversion)
+      version=$(cat "$appversionFile")
       verifyReleaseVersion "$version"
       setArtifactVersion "$version-$GITHUB_RUN_NUMBER"
       ;;


### PR DESCRIPTION
JIRA -> [BAH-4107](https://bahmni.atlassian.net/browse/BAH-4107)

This PR aims to enhance the `setArtifactVersion.sh` script to allow passing a custom version file as an optional argument. If no argument is provided, the script should default to using the `package/.appversion` file.