### PR TITLE
BAH-4548 | Fix. Trivy to patched version 0.69.3

### DIFF
--- a/trivy_scan.sh
+++ b/trivy_scan.sh
@@ -5,7 +5,7 @@ sudo apt-get install wget apt-transport-https gnupg lsb-release
 wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add -
 echo deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main | sudo tee -a /etc/apt/sources.list.d/trivy.list
 sudo apt-get update
-sudo apt-get install trivy
+sudo apt-get install trivy=0.69.3
 
 #Make an array of input paths
 TARGETS=("$@")


### PR DESCRIPTION
**JIRA** → [BAH-4548](https://bahmni.atlassian.net/browse/BAH-4548)

### **Description**

This PR patches the security issue with Trivy. The installed version has been fixed to 0.69.3

---

### **References**
- https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23
- https://github.com/aquasecurity/trivy/discussions/10425

[BAH-4548]: https://bahmni.atlassian.net/browse/BAH-4548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ