### PR TITLE
[BAH-4696]: Fix Bahmni Docker Image security vulnerability Scanner

### DIFF
--- a/image-scanner.sh
+++ b/image-scanner.sh
@@ -101,11 +101,13 @@ ORG="$1"
 # Check if trivy is installed and install it if not
 if ! command -v trivy &> /dev/null; then
     echo "Trivy is not installed. Installing..."
-    wget https://github.com/aquasecurity/trivy/releases/download/v0.51.1/trivy_0.51.1_Linux-64bit.deb
-    sudo dpkg -i trivy_0.51.1_Linux-64bit.deb
-else
-    echo "Found trivy, using trivy v$(trivy -v | cut -d ' ' -f 2)"
+    curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+    if ! command -v trivy &> /dev/null; then
+        echo "Error: Trivy installation failed."
+        exit 1
+    fi
 fi
+echo "Using trivy v$(trivy -v | head -1 | awk '{print $2}')"
 
 # Start the text report
 summary_file_output="Trivy Scan Results Summary\n"

--- a/image-scanner.sh
+++ b/image-scanner.sh
@@ -101,7 +101,7 @@ ORG="$1"
 # Check if trivy is installed and install it if not
 if ! command -v trivy &> /dev/null; then
     echo "Trivy is not installed. Installing..."
-    curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+    curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.70.0
     if ! command -v trivy &> /dev/null; then
         echo "Error: Trivy installation failed."
         exit 1

--- a/image-scanner.sh
+++ b/image-scanner.sh
@@ -98,10 +98,13 @@ fi
 # Get Docker Organization Name from the script argument
 ORG="$1"
 
+# Trivy version to install
+TRIVY_VERSION="0.70.0"
+
 # Check if trivy is installed and install it if not
 if ! command -v trivy &> /dev/null; then
     echo "Trivy is not installed. Installing..."
-    curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.70.0
+    curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v${TRIVY_VERSION}
     if ! command -v trivy &> /dev/null; then
         echo "Error: Trivy installation failed."
         exit 1


### PR DESCRIPTION
## Issue                                                                                                                                                                                              
  Fixed silent failure in Trivy installation for daily security scanning. Replaced hardcoded wget+dpkg install with Aqua Security's official curl installer, and added explicit exit guard to prevent silent failures.                                                                                                                                                                               
                                                                                                                                                                                                            
  ## Changes                                                                                                                                                                                        
  - `image-scanner.sh` (lines 102-110): Replaced hardcoded v0.51.1 .deb URL with Aqua's official install.sh script via curl                                                                               
  - Added post-install validation: exits rc=1 if Trivy installation fails                                                                                                                                   
  - Moved version-echo outside the if block so it runs unconditionally after install                                                                                                                        
                                                                                                                                                                                                            
  ## Reason                                                                                                                                                                                                 
  The hardcoded v0.51.1 .deb URL (`https://github.com/aquasecurity/trivy/releases/download/v0.51.1/trivy_0.51.1_Linux-64bit.deb`) returns HTTP 404. As a result:                                            
  - Every daily `scan_images.yaml` workflow run was failing                                                                                                                                                 
  - Trivy was never installed, but the script had no exit guard
  - Workflow reported green even though no scans happened                                                                                                                                                   
  - Security reports stale for weeks with no visibility                                                                                                                                                     
                                                                                                                                                                                                            
  ## Testing                                                                                                                                                                                                
  - [x] AC1 — Fresh install: Trivy v0.70.0 installed cleanly on ubuntu:22.04                                                                                                                                
  - [x] AC3 — Failure path: Script exits rc=1 loudly when install fails                                                                                                                                   
  - [ ] AC2 & AC4 — End-to-end: Requires post-merge workflow_dispatch in bahmni-docker                                                                                                                      
                                                                                                                                                                                                            
  ## Verification                                                                                                                                                                                           
  Post-merge: Trigger `scan_images.yaml` via workflow_dispatch in `Bahmni/bahmni-docker` and confirm:                                                                                                       
  - Workflow completes successfully                                                                                                                                                                         
  - New commit appears in `Bahmni/security-reports` with dated HTML reports
                                                                                                                                                                                                            
  ## Follow-ups (out of scope)                                                                                                                                                                            
  - Harden `bahmni-docker` workflow to use `aquasecurity/setup-trivy` action                                                                                                                                
  - Align sibling `trivy_scan.sh` to use same curl installer pattern                                                                                                                                        
  - Consider pinning Trivy version via `-v` flag for consistency   

  ## Outcome  
AC1
<img width="946" height="411" alt="image" src="https://github.com/user-attachments/assets/2e87337a-3a42-42fc-8e07-1d0914161f88" />

AC3
<img width="733" height="545" alt="image" src="https://github.com/user-attachments/assets/57aa9922-978e-4b31-b9b0-ac6e67acc730" />

                                                                                                                                       
                                                                                                                                                                                                          